### PR TITLE
Медот query.first() для получения первого объекта

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -43,10 +43,9 @@ Parse.Cloud.define("getCredentials", function(request, response) {
 
         var query = new Parse.Query(Parse.User);
         query.equalTo("username", userLogin);
-        query.find({
-            success: function(result) {
+        query.first({
+            success: function(user) {
                 if (result.length) {
-                    var user = result[0];
                     updateUser(user);
                 } else {
                     signUp();


### PR DESCRIPTION
Метод first() вместо query.find()  для получения первого объекта